### PR TITLE
Generic viewport

### DIFF
--- a/examples/camera_annotation.py
+++ b/examples/camera_annotation.py
@@ -77,7 +77,6 @@ def main():
         scenario=os.path.join(root, 'scenarios', 'replay_tcd_60mph_short.json'),
         sensors=os.path.join(root, 'configurations', 'sensors_annotated_camera.json'),
         weather=os.path.join(root, 'configurations', 'weather.json'),
-        ego=os.path.join(root, 'configurations', 'vehicle.json'),
         verbose=VERBOSE
     )
 

--- a/examples/closed_loop_hud.py
+++ b/examples/closed_loop_hud.py
@@ -48,7 +48,7 @@ def camera_on_update(frame: CameraFrame):
 
 def perception_and_control():
     # TODO, process sensor data and determine control values to send to ego
-    return 1, 0, 0, 1  # fwd, right, brake, mode
+    return 0.4, 0, 0, 1  # fwd, right, brake, mode
 
 
 def main():
@@ -73,7 +73,6 @@ def main():
         scenario=os.path.join(root, 'scenarios', 'closed_loop.json'),
         sensors=os.path.join(root, 'configurations', 'sensors_hud.json'),
         weather=os.path.join(root, 'configurations', 'weather.json'),
-        ego=os.path.join(root, 'configurations', 'vehicle.json'),
         verbose=VERBOSE
     )
 
@@ -89,13 +88,12 @@ def main():
 
         # setup display
         if DISPLAY:
-            fig = plt.figure('perception system', figsize=(10, 4))
-            ax_camera = fig.add_subplot(1, 2, 1)
+            fig = plt.figure('perception system', figsize=(5, 5))
+            ax_camera = fig.add_subplot(1, 1, 1)
             ax_camera.set_axis_off()
 
             fig.canvas.draw()
             data_camera = None
-            data_lidar = None
 
         i = 0
         while running and i < 100:

--- a/examples/configurations/sensors.json
+++ b/examples/configurations/sensors.json
@@ -25,7 +25,26 @@
     "min_shutter": 0.000500,
     "max_shutter": 0.001400,
     "sensor_size": 9.07,
-    "channels": "bgra"
+    "channels": "bgra",
+    "annotation": {
+      "include_annotation": false,
+      "desired_tags": [
+        "traffic_sign"
+      ],
+      "far_plane": 10000.0,
+      "include_tags": true,
+      "include_obb": true
+    },
+    "viewport": {
+      "enable_viewport": false,
+      "fullscreen": false,
+      "monitor_name": "",
+      "monitor_number": -1,
+      "window_offset": {
+        "x": 0,
+        "y": 0
+      }
+    }
   },
   {
     "type": "Lidar",

--- a/examples/configurations/simulator.json
+++ b/examples/configurations/simulator.json
@@ -6,7 +6,6 @@
   "simulation_mode": 2,
   "animation_replay": true,
   "map": "Almono",
-  "ego_config": {},
   "phys_materials": {
     "Aluminum": {
       "specular_exponent": 15.0,

--- a/examples/replay.py
+++ b/examples/replay.py
@@ -106,7 +106,6 @@ def main():
         scenario=os.path.join(root, 'scenarios', 'replay_highway_exit.json'),
         sensors=os.path.join(root, 'configurations', 'sensors.json'),
         weather=os.path.join(root, 'configurations', 'weather.json'),
-        ego=os.path.join(root, 'configurations', 'vehicle.json'),
         verbose=VERBOSE
     )
 

--- a/monodrive/sensors/base_sensor.py
+++ b/monodrive/sensors/base_sensor.py
@@ -42,7 +42,8 @@ class Sensor(objectfactory.Serializable):
     sensor_type = objectfactory.Field(name='type')
     listen_port = objectfactory.Field()
     packet_size = objectfactory.Field()
-    fps = objectfactory.Field()
+    enable_streaming = objectfactory.Field(default=True)
+    wait_for_fresh_frame = objectfactory.Field(default=True)
     location = objectfactory.Nested(field_type=SensorLocation)
     rotation = objectfactory.Nested(field_type=SensorRotation)
 
@@ -56,7 +57,6 @@ class Sensor(objectfactory.Serializable):
         """
         super().__init__(*args, **kwargs)
         self.blocks_per_frame = 1
-        self.streamable = True
 
     def configure(self):
         """Function called after deserializing sensor to do any setup/config"""
@@ -124,7 +124,7 @@ class SensorThread(threading.Thread):
             the data arrived, the second element is the game time the data
             occurred, and the third element is the data message.
         """
-        if not self.__sensor.streamable:
+        if not self.__sensor.enable_streaming:
             print('Error: cannot subscribe to sensor of type: {}'.format(self.__sensor.sensor_type))
             return
         self.__source.subscribe(lambda data: callback(data))

--- a/monodrive/sensors/camera.py
+++ b/monodrive/sensors/camera.py
@@ -104,3 +104,20 @@ class SemanticCamera(Camera):
         configure semantic camera
         """
         self.channels = 'gray'
+
+
+@objectfactory.Factory.register_class
+class Camera360(Camera):
+    """360 Camera sensor"""
+
+    def configure(self):
+        """
+        no support for annotation
+        """
+        pass
+
+
+@objectfactory.Factory.register_class
+class FisheyeCamera(Camera360):
+    """Fisheye Camera sensor"""
+    pass

--- a/monodrive/sensors/gps.py
+++ b/monodrive/sensors/gps.py
@@ -43,7 +43,7 @@ class GPS(Sensor):
             parsed GPSFrame object
         """
         data = data[0]
-        fmt = '=chhcdddfffffffhhcch'
+        fmt = '>chhcdddfffffffhhcch'
         preamble, MSG_POS_LLH, sensor_id, payload_length, lat, lng, elev, loc_x, loc_y, for_x, for_y, for_z, ego_yaw, speed, \
         h_ac, v_ac, sats, status, crc = list(struct.unpack(fmt, data))
         forward_vector = np.array([for_x, for_y, for_z])

--- a/monodrive/sensors/imu.py
+++ b/monodrive/sensors/imu.py
@@ -38,7 +38,7 @@ class IMU(Sensor):
             parsed GPSFrame object
         """
         data = data[0]
-        fmt = '=ffffffih'
+        fmt = '>ffffffih'
         data = list(struct.unpack(fmt, data[1:31]))
         accel_x = data[0]
         accel_y = data[1]

--- a/monodrive/sensors/rpm.py
+++ b/monodrive/sensors/rpm.py
@@ -38,7 +38,7 @@ class RPM(Sensor):
         """
         data = data[0]
         frame = RPMFrame()
-        frame.wheel_number, frame.wheel_speed = list(struct.unpack('=if', data))
+        frame.wheel_number, frame.wheel_speed = list(struct.unpack('>if', data))
         frame.sensor_id = self.id
         frame.timestamp = time
         frame.game_time = game_time

--- a/monodrive/sensors/viewport_camera.py
+++ b/monodrive/sensors/viewport_camera.py
@@ -18,7 +18,7 @@ class ViewportCamera(Sensor):
         """
         Configure ViewportCamera sensor
         """
-        self.streamable = False
+        self.enable_streaming = False
 
     def parse(self, data: [bytes], package_length: int, time: int, game_time: int):
         """

--- a/monodrive/simulator/simulator.py
+++ b/monodrive/simulator/simulator.py
@@ -195,7 +195,7 @@ class Simulator:
 
         sensor = objectfactory.Factory.create_object(updated_config)
         sensor.configure()
-        if sensor.streamable:
+        if sensor.enable_streaming:
             if sensor.id not in self.__sensors:
                 raise Exception(
                     "{} does not yet exist and cannot be reconfigured".format(sensor.id)
@@ -298,7 +298,7 @@ class Simulator:
             sc['_type'] = sc['type']
             sensor = objectfactory.Factory.create_object(sc)
             sensor.configure()
-            if not sensor.streamable:
+            if not sensor.enable_streaming:
                 continue
             sensor_thread = SensorThread(
                 self.__config['server_ip'],


### PR DESCRIPTION
## Overview
This PR adds support for the generic camera viewport to render/display camera data on the server side without streaming to client. This feature works for standard camera, fisheye and 360.

## Changes
- respect `enable_streaming` field in sensor config
- adds viewport config example within `sensors.json`
- adds support for `Camera360` and `FisheyeCamera`
- various other cleanup and parsing fixes

## Testing
Enable the viewport in `sensors.json` and run one of the examples to verify that a server side window opens and display camera data

Modify an example to use `FisheyeCamera` or `Camera360` and validate the data output. Note you will also need to update the key in the python code where subscribing to the sensor callback

