### PR TITLE
multiple fisheye models

### DIFF
--- a/monodrive/sensors/camera.py
+++ b/monodrive/sensors/camera.py
@@ -124,6 +124,6 @@ class Poly1FisheyeCamera(Camera360):
 
 
 @objectfactory.Factory.register_class
-class EquidistantFisheyeCameraConfig(Camera360):
+class EquidistantFisheyeCamera(Camera360):
     """Equidistant Fisheye Camera sensor"""
     pass

--- a/monodrive/sensors/camera.py
+++ b/monodrive/sensors/camera.py
@@ -118,6 +118,12 @@ class Camera360(Camera):
 
 
 @objectfactory.Factory.register_class
-class FisheyeCamera(Camera360):
-    """Fisheye Camera sensor"""
+class Poly1FisheyeCamera(Camera360):
+    """Poly1 Fisheye Camera sensor"""
+    pass
+
+
+@objectfactory.Factory.register_class
+class EquidistantFisheyeCameraConfig(Camera360):
+    """Equidistant Fisheye Camera sensor"""
     pass


### PR DESCRIPTION
## Overview
This updates the camera module to support both multiple different fisheye models

## Changes
- rename `FisheyeCamera` to `EquidistantFisheyeCamera`
- adds `Poly1FisheyeCamera`

## Testing
Add a fisheye to any example and validate output data. Note you will also need to update the key in the python code where subscribing to the sensor callback.

Here's an example configuration template
```json
  {
    "type": "Poly1FisheyeCamera",
    "packet_size": 23552,
    "listen_port": 8000,
    "location": {
      "x": 0.0,
      "y": 0.0,
      "z": 225.0
    },
    "rotation": {
      "pitch": -15.0,
      "yaw": 0.0,
      "roll": 0.0
    },
    "stream_dimensions": {
      "x": 1280.0,
      "y": 800.0
    },
    "face_size": 768,
    "a0": 349.126,
    "a2": -0.0011,
    "a3": 1.1978e-06,
    "a4": -1.5119e-09,
    "fov": 180.0,
    "fstop": 1.4,
    "min_shutter": 0.000500,
    "max_shutter": 0.001400,
    "sensor_size": 9.07,
    "channels": "bgra",
    "viewport": {
      "enable_viewport": false,
      "fullscreen": false,
      "monitor_name": "",
      "monitor_number": -1,
      "window_offset": {
        "x": 0,
        "y": 0
      }
    }
  },
```